### PR TITLE
Include iostream for stream operators

### DIFF
--- a/src/NSPlist.cpp
+++ b/src/NSPlist.cpp
@@ -16,6 +16,7 @@
 
 #include <assert.h>
 #include <stdio.h>
+#include <iostream>
 
 #include "NSPlist.h"
 


### PR DESCRIPTION
Compiling with clang and g++ I get compile errors regarding the stream operator (`<<`). The `iostream` header (or one of its included headers) has the proper definitions for these overloads.
